### PR TITLE
Fix benchmark data initialization to fill full FFT input arrays

### DIFF
--- a/src/__benchmarks__/index.bench.ts
+++ b/src/__benchmarks__/index.bench.ts
@@ -40,7 +40,8 @@ function randomData(): [Float64Array, Float64Array] {
   const N = Math.floor(11 + Math.random() * 4);
   const real = new Float64Array(1 << N);
   const imag = new Float64Array(1 << N);
-  for (let i = 0; i < N; ++i) {
+  const len = real.length;
+  for (let i = 0; i < len; ++i) {
     real[i] = Math.random() * 2 - 1;
     imag[i] = Math.random() * 2 - 1;
   }
@@ -59,7 +60,8 @@ describe('Random power of two', () => {
   bench('Forward no imaginary', () => {
     const N = Math.floor(11 + Math.random() * 4);
     const real = new Float64Array(1 << N);
-    for (let i = 0; i < N; ++i) {
+    const len = real.length;
+    for (let i = 0; i < len; ++i) {
       real[i] = Math.random() * 2 - 1;
     }
     fft(real);


### PR DESCRIPTION
### Motivation

- The benchmark helpers allocated power-of-two `Float64Array` buffers but only initialized `N` elements where `N` was the exponent, leaving most of the buffer uninitialized and producing an incorrect workload.

### Description

- Change `randomData()` in `src/__benchmarks__/index.bench.ts` to compute `const len = real.length` and iterate `for (let i = 0; i < len; ++i)` when filling `real` and `imag` arrays so the full buffer is initialized.
- Apply the same fix in the `Random power of two` → `Forward no imaginary` benchmark by using `const len = real.length` and iterating to `len` when filling the real-only array.

### Testing

- Ran the benchmark suite with `npm run bench` on the original (pre-fix) code to capture baseline behavior and the command completed successfully.
- Reran the benchmark suite with `npm run bench` after the fix and the command completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c417d9e5bc832b9d6e1f25b07ebd3a)