### PR TITLE
Add package exports map and document public import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ const [realSignalScaled, imagSignalScaled] = ifft(realCoefs, imagCoefs);
 // The original signal reconstructed (with some floating point noise).
 const realSignal = ifftReal(realCoefs, imagCoefs).map(s => s / 256);
 ```
+## Supported imports
+Use only the package root import:
+
+```typescript
+import {fft, ifft, ifftReal} from 'frost-fft';
+```
+
+Public export path(s):
+- `frost-fft`
+
+Do not import from internal build paths such as `frost-fft/dist/*`; those are not part of the public API contract and may change.
+
 
 ## Documentation ##
 Documentation is hosted at the project [Github pages](https://frostburn.github.io/frost-fft).

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "github",
     "url": "https://github.com/sponsors/frostburn"
   },
-  "main": "dist/index",
+  "main": "dist/index.js",
   "files": [
     "dist"
   ],
@@ -41,5 +41,13 @@
     "typedoc": "^0.28.18",
     "typescript": "^5.9.3",
     "vitest": "^4.1.1"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   }
 }


### PR DESCRIPTION
### Motivation
- Ensure modern Node/TypeScript consumers and bundlers can resolve the package entry via the package `exports` field while keeping backwards compatibility.
- Prevent consumers from relying on non-public internal build paths by documenting the supported import surface.

### Description
- Added an `exports` map to `package.json` with a root entry (`"."`) that points `import`, `require`, `default` to `./dist/index.js` and `types` to `./dist/index.d.ts`.
- Kept `types` and `main` fields for backward compatibility and aligned `main` to `dist/index.js` used by `exports`.
- Updated `README.md` to document the supported import path (`import {fft, ifft, ifftReal} from 'frost-fft';`) and warn against importing internal `frost-fft/dist/*` paths.

### Testing
- Ran `npm run compile` successfully to build `dist` artifacts.
- Packed and installed the tarball into a temporary consumer and verified runtime ESM import with a node script that executed `import {fft} from 'frost-fft'` (success).
- Verified TypeScript resolution/compilation with `moduleResolution: "NodeNext"` and `moduleResolution: "Bundler"` using `npx tsc` (both succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c417e17b38832b86e8c19729796e85)