### PR TITLE
Optimize recursive FFT input splitting

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,35 @@ function getTables(M: number): [number[], number[]] {
   return [cosines, sines];
 }
 
+function splitComplexEvenOdd(
+  realIn: Float64Array,
+  imagIn: Float64Array,
+): [Float64Array, Float64Array, Float64Array, Float64Array] {
+  const M = realIn.length >>> 1;
+  const realEvensIn = new Float64Array(M);
+  const imagEvensIn = new Float64Array(M);
+  const realOddsIn = new Float64Array(M);
+  const imagOddsIn = new Float64Array(M);
+  for (let i = 0, j = 0; i < M; ++i, j += 2) {
+    realEvensIn[i] = realIn[j];
+    imagEvensIn[i] = imagIn[j];
+    realOddsIn[i] = realIn[j + 1];
+    imagOddsIn[i] = imagIn[j + 1];
+  }
+  return [realEvensIn, imagEvensIn, realOddsIn, imagOddsIn];
+}
+
+function splitRealEvenOdd(realIn: Float64Array): [Float64Array, Float64Array] {
+  const M = realIn.length >>> 1;
+  const realEvensIn = new Float64Array(M);
+  const realOddsIn = new Float64Array(M);
+  for (let i = 0, j = 0; i < M; ++i, j += 2) {
+    realEvensIn[i] = realIn[j];
+    realOddsIn[i] = realIn[j + 1];
+  }
+  return [realEvensIn, realOddsIn];
+}
+
 /**
  * Calculate the smallest power of two greater or equal to the input value.
  * @param x Integer to compare to.
@@ -149,14 +178,10 @@ function _fft(
     return [realOut, imagOut];
   }
 
-  const [realEvens, imagEvens] = _fft(
-    realIn.filter((_, k) => !(k & 1)),
-    imagIn.filter((_, k) => !(k & 1)),
-  );
-  const [realOdds, imagOdds] = _fft(
-    realIn.filter((_, k) => k & 1),
-    imagIn.filter((_, k) => k & 1),
-  );
+  const [realEvensIn, imagEvensIn, realOddsIn, imagOddsIn] =
+    splitComplexEvenOdd(realIn, imagIn);
+  const [realEvens, imagEvens] = _fft(realEvensIn, imagEvensIn);
+  const [realOdds, imagOdds] = _fft(realOddsIn, imagOddsIn);
 
   const M = N >>> 1;
 
@@ -249,10 +274,9 @@ function _fftNoImagInner(realIn: Float64Array): [Float64Array, Float64Array] {
     return [realOut, imagOut];
   }
 
-  const [realEvens, imagEvens] = _fftNoImagInner(
-    realIn.filter((_, k) => !(k & 1)),
-  );
-  const [realOdds, imagOdds] = _fftNoImagInner(realIn.filter((_, k) => k & 1));
+  const [realEvensIn, realOddsIn] = splitRealEvenOdd(realIn);
+  const [realEvens, imagEvens] = _fftNoImagInner(realEvensIn);
+  const [realOdds, imagOdds] = _fftNoImagInner(realOddsIn);
 
   const M = N >>> 1;
 
@@ -375,14 +399,10 @@ function _ifft(
 
     return [realOut, imagOut];
   }
-  const [realEvens, imagEvens] = _ifft(
-    realIn.filter((_, k) => !(k & 1)),
-    imagIn.filter((_, k) => !(k & 1)),
-  );
-  const [realOdds, imagOdds] = _ifft(
-    realIn.filter((_, k) => k & 1),
-    imagIn.filter((_, k) => k & 1),
-  );
+  const [realEvensIn, imagEvensIn, realOddsIn, imagOddsIn] =
+    splitComplexEvenOdd(realIn, imagIn);
+  const [realEvens, imagEvens] = _ifft(realEvensIn, imagEvensIn);
+  const [realOdds, imagOdds] = _ifft(realOddsIn, imagOddsIn);
 
   const M = N >>> 1;
 
@@ -478,14 +498,10 @@ function _ifftReal(realIn: Float64Array, imagIn: Float64Array): Float64Array {
 
     return realOut;
   }
-  const realEvens = _ifftReal(
-    realIn.filter((_, k) => !(k & 1)),
-    imagIn.filter((_, k) => !(k & 1)),
-  );
-  const [realOdds, imagOdds] = _ifft(
-    realIn.filter((_, k) => k & 1),
-    imagIn.filter((_, k) => k & 1),
-  );
+  const [realEvensIn, imagEvensIn, realOddsIn, imagOddsIn] =
+    splitComplexEvenOdd(realIn, imagIn);
+  const realEvens = _ifftReal(realEvensIn, imagEvensIn);
+  const [realOdds, imagOdds] = _ifft(realOddsIn, imagOddsIn);
 
   const M = N >>> 1;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,8 +40,8 @@ function getTables(M: number): [number[], number[]] {
 function splitComplexEvenOdd(
   realIn: Float64Array,
   imagIn: Float64Array,
+  M: number,
 ): [Float64Array, Float64Array, Float64Array, Float64Array] {
-  const M = realIn.length >>> 1;
   const realEvensIn = new Float64Array(M);
   const imagEvensIn = new Float64Array(M);
   const realOddsIn = new Float64Array(M);
@@ -55,8 +55,10 @@ function splitComplexEvenOdd(
   return [realEvensIn, imagEvensIn, realOddsIn, imagOddsIn];
 }
 
-function splitRealEvenOdd(realIn: Float64Array): [Float64Array, Float64Array] {
-  const M = realIn.length >>> 1;
+function splitRealEvenOdd(
+  realIn: Float64Array,
+  M: number,
+): [Float64Array, Float64Array] {
   const realEvensIn = new Float64Array(M);
   const realOddsIn = new Float64Array(M);
   for (let i = 0, j = 0; i < M; ++i, j += 2) {
@@ -178,12 +180,11 @@ function _fft(
     return [realOut, imagOut];
   }
 
+  const M = N >>> 1;
   const [realEvensIn, imagEvensIn, realOddsIn, imagOddsIn] =
-    splitComplexEvenOdd(realIn, imagIn);
+    splitComplexEvenOdd(realIn, imagIn, M);
   const [realEvens, imagEvens] = _fft(realEvensIn, imagEvensIn);
   const [realOdds, imagOdds] = _fft(realOddsIn, imagOddsIn);
-
-  const M = N >>> 1;
 
   realOut[0] = realEvens[0] + realOdds[0];
   realOut[M] = realEvens[0] - realOdds[0];
@@ -274,11 +275,10 @@ function _fftNoImagInner(realIn: Float64Array): [Float64Array, Float64Array] {
     return [realOut, imagOut];
   }
 
-  const [realEvensIn, realOddsIn] = splitRealEvenOdd(realIn);
+  const M = N >>> 1;
+  const [realEvensIn, realOddsIn] = splitRealEvenOdd(realIn, M);
   const [realEvens, imagEvens] = _fftNoImagInner(realEvensIn);
   const [realOdds, imagOdds] = _fftNoImagInner(realOddsIn);
-
-  const M = N >>> 1;
 
   realOut[0] = realEvens[0] + realOdds[0];
   realOut[M] = realEvens[0] - realOdds[0];
@@ -399,12 +399,11 @@ function _ifft(
 
     return [realOut, imagOut];
   }
+  const M = N >>> 1;
   const [realEvensIn, imagEvensIn, realOddsIn, imagOddsIn] =
-    splitComplexEvenOdd(realIn, imagIn);
+    splitComplexEvenOdd(realIn, imagIn, M);
   const [realEvens, imagEvens] = _ifft(realEvensIn, imagEvensIn);
   const [realOdds, imagOdds] = _ifft(realOddsIn, imagOddsIn);
-
-  const M = N >>> 1;
 
   realOut[0] = realEvens[0] + realOdds[0];
   realOut[M] = realEvens[0] - realOdds[0];
@@ -498,12 +497,11 @@ function _ifftReal(realIn: Float64Array, imagIn: Float64Array): Float64Array {
 
     return realOut;
   }
+  const M = N >>> 1;
   const [realEvensIn, imagEvensIn, realOddsIn, imagOddsIn] =
-    splitComplexEvenOdd(realIn, imagIn);
+    splitComplexEvenOdd(realIn, imagIn, M);
   const realEvens = _ifftReal(realEvensIn, imagEvensIn);
   const [realOdds, imagOdds] = _ifft(realOddsIn, imagOddsIn);
-
-  const M = N >>> 1;
 
   realOut[0] = realEvens[0] + realOdds[0];
   realOut[M] = realEvens[0] - realOdds[0];


### PR DESCRIPTION
### Motivation

- Reduce per-recursion overhead and temporary allocations in the recursive FFT paths by avoiding `TypedArray.filter(...)` callbacks and intermediate array churn.

### Description

- Add `splitComplexEvenOdd` and `splitRealEvenOdd` helpers that copy even/odd elements using tight indexed loops instead of using `filter` callbacks. 
- Replace `filter`-based even/odd splitting with the new helpers in `_fft`, `_fftNoImagInner`, `_ifft`, and `_ifftReal`.
- Changes are contained in `src/index.ts` and preserve the existing algorithm and public API.

### Testing

- Ran `npm test` which compiles the TypeScript and executes the Vitest suite, and all tests passed (`18 passed`).
- Ran the benchmark suite with `npm run bench`, which completed successfully and produced benchmark output.
- Linting (`gts lint`) and TypeScript compilation completed as part of the test lifecycle.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c41b36d118832ba4b86af7d0873bf8)